### PR TITLE
Fix/post type visibility

### DIFF
--- a/admin/class-wp-rest-api-log-admin.php
+++ b/admin/class-wp-rest-api-log-admin.php
@@ -55,7 +55,7 @@ if ( ! class_exists( 'WP_REST_API_Log_Admin' ) ) {
 			$min = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.min' : '';
 
 			// https://highlightjs.org/
-			$highlight_version = apply_filters( 'wp-rest-api-log-admin-highlight-js-version', '9.6.0' );
+			$highlight_version = apply_filters( 'wp-rest-api-log-admin-highlight-js-version', '9.7.0' );
 			$highlight_style   = apply_filters( 'wp-rest-api-log-admin-highlight-js-version', 'github' );
 
 			wp_register_script( 'wp-rest-api-log-admin-highlight-js',   '//cdnjs.cloudflare.com/ajax/libs/highlight.js/' . $highlight_version . '/highlight.min.js' );

--- a/includes/class-wp-rest-api-log-common.php
+++ b/includes/class-wp-rest-api-log-common.php
@@ -7,7 +7,7 @@ if ( ! class_exists( 'WP_REST_API_Log_Common' ) ) {
 	class WP_REST_API_Log_Common {
 
 		const PLUGIN_NAME      = 'wp-rest-api-log';
-		const VERSION          = '2016-08-21-01';
+		const VERSION          = '2016-10-06-01';
 		const TEXT_DOMAIN      = 'wp-rest-api-log';
 
 

--- a/includes/class-wp-rest-api-log-post-type.php
+++ b/includes/class-wp-rest-api-log-post-type.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'WP_REST_API_Log_Post_type' ) ) {
 				'show_in_rest'        => true,
 				'rest_base'           => WP_REST_API_Log_DB::POST_TYPE, // allows the CPT to show up in the native API
 				'hierarchical'        => false,
-				'public'              => true,
+				'public'              => false,
 				'show_ui'             => true,
 				'show_in_menu'        => 'tools.php',
 				'show_in_admin_bar'   => false,

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ Includes:
 * WordPress admin page to view and search log entries
 * API endpoint to access log entries via JSON
 * filters to customize logging
+* Custom endpoint logging
 * ElasticPress logging
 
 Find us on [GitHub](https://github.com/petenelson/wp-rest-api-log)!
@@ -42,6 +43,11 @@ Roadmap
 
 
 ## Changelog ##
+
+### v1.4.0 October 6, 2016 ###
+* Changed plugin name to REST API Log
+* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing
+  up in searches.
 
 ### v1.3.0 August 21, 2016 ###
 * Updated Highlight JS version
@@ -74,6 +80,11 @@ Roadmap
 
 
 ## Upgrade Notice ##
+
+### v1.4.0 October 6, 2016 ###
+* Changed plugin name to REST API Log
+* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing
+  up in searches.
 
 ### v1.3.0 August 21, 2016 ###
 * Updated Highlight JS version

--- a/readme.md
+++ b/readme.md
@@ -12,11 +12,11 @@
 [![Travis CI](https://travis-ci.org/petenelson/wp-rest-api-log.svg)](https://travis-ci.org/petenelson/wp-rest-api-log)
 
 
-WordPress plugin to log WP REST API requests and responses
+WordPress plugin to log REST API requests and responses
 
 ## Description ##
 
-WordPress plugin to log [WP REST API](http://v2.wp-api.org/) requests and responses (for v2 of the API).
+WordPress plugin to log [REST API](http://v2.wp-api.org/) requests and responses (for v2 of the API).
 
 Includes:
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ WordPress plugin to log WP REST API requests and responses
 
 ## Description ##
 
-WordPress plugin to log [WP REST API](http://wp-api.org/) requests and responses (for v2 of the API).
+WordPress plugin to log [WP REST API](http://v2.wp-api.org/) requests and responses (for v2 of the API).
 
 Includes:
 

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
-# WP REST API Log #
+# REST API Log #
 **Contributors:** gungeekatx  
-**Tags:** wp rest api, rest api, wp api, api, json, log  
+**Tags:** wp rest api, rest api, wp api, api, json, log, logging  
 **Donate link:** https://github.com/petenelson/wp-rest-api-log  
 **Requires at least:** 4.0  
 **Tested up to:** 4.6  
-**Stable tag:** 1.2.0  
+**Stable tag:** 1.3.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -46,11 +46,8 @@ Roadmap
 
 ### v1.4.0 October 6, 2016 ###
 * Changed plugin name to REST API Log
-* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing
-  up in searches.
-
-### v1.3.0 August 21, 2016 ###
-* Updated Highlight JS version
+* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing up in searches.
+* Updated Highlight JS version to 9.7.0
 * Updated the internal process for granting administrator role access to the custom post type
 
 ### v1.2.0 July 6, 2016 ###
@@ -83,11 +80,8 @@ Roadmap
 
 ### v1.4.0 October 6, 2016 ###
 * Changed plugin name to REST API Log
-* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing
-  up in searches.
-
-### v1.3.0 August 21, 2016 ###
-* Updated Highlight JS version
+* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing up in searches.
+* Updated Highlight JS version to 9.7.0
 * Updated the internal process for granting administrator role access to the custom post type
 
 ## Frequently Asked Questions ##

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,7 @@ Includes:
 * WordPress admin page to view and search log entries
 * API endpoint to access log entries via JSON
 * filters to customize logging
+* Custom endpoint logging
 * ElasticPress logging
 
 Find us on [GitHub](https://github.com/petenelson/wp-rest-api-log)!
@@ -38,6 +39,11 @@ Roadmap
 
 
 == Changelog ==
+
+= v1.4.0 October 6, 2016 =
+* Changed plugin name to REST API Log
+* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing
+  up in searches.
 
 = v1.3.0 August 21, 2016 =
 * Updated Highlight JS version
@@ -70,6 +76,11 @@ Roadmap
 
 
 == Upgrade Notice ==
+
+= v1.4.0 October 6, 2016 =
+* Changed plugin name to REST API Log
+* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing
+  up in searches.
 
 = v1.3.0 August 21, 2016 =
 * Updated Highlight JS version

--- a/readme.txt
+++ b/readme.txt
@@ -8,11 +8,11 @@ Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-WordPress plugin to log WP REST API requests and responses
+WordPress plugin to log REST API requests and responses
 
 == Description ==
 
-WordPress plugin to log [WP REST API](http://v2.wp-api.org/) requests and responses (for v2 of the API).
+WordPress plugin to log [REST API](http://v2.wp-api.org/) requests and responses (for v2 of the API).
 
 Includes:
 

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ WordPress plugin to log WP REST API requests and responses
 
 == Description ==
 
-WordPress plugin to log [WP REST API](http://wp-api.org/) requests and responses (for v2 of the API).
+WordPress plugin to log [WP REST API](http://v2.wp-api.org/) requests and responses (for v2 of the API).
 
 Includes:
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
-=== WP REST API Log ===
+=== REST API Log ===
 Contributors: gungeekatx
-Tags: wp rest api, rest api, wp api, api, json, log
+Tags: wp rest api, rest api, wp api, api, json, log, logging
 Donate link: https://github.com/petenelson/wp-rest-api-log
 Requires at least: 4.0
 Tested up to: 4.6
-Stable tag: 1.2.0
+Stable tag: 1.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -42,11 +42,8 @@ Roadmap
 
 = v1.4.0 October 6, 2016 =
 * Changed plugin name to REST API Log
-* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing
-  up in searches.
-
-= v1.3.0 August 21, 2016 =
-* Updated Highlight JS version
+* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing up in searches.
+* Updated Highlight JS version to 9.7.0
 * Updated the internal process for granting administrator role access to the custom post type
 
 = v1.2.0 July 6, 2016 =
@@ -79,11 +76,8 @@ Roadmap
 
 = v1.4.0 October 6, 2016 =
 * Changed plugin name to REST API Log
-* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing
-  up in searches.
-
-= v1.3.0 August 21, 2016 =
-* Updated Highlight JS version
+* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing up in searches.
+* Updated Highlight JS version to 9.7.0
 * Updated the internal process for granting administrator role access to the custom post type
 
 == Frequently Asked Questions ==

--- a/wp-rest-api-log.php
+++ b/wp-rest-api-log.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Plugin Name: WP REST API Log
- * Description: Logs requests and responses for the WP REST API
+ * Plugin Name: REST API Log
+ * Description: Logs requests and responses for the REST API
  * Author: Pete Nelson
- * Version: 1.3.0
+ * Version: 1.4.0
  * Plugin URI: https://github.com/petenelson/wp-rest-api-log
  * Text Domain: wp-rest-api-log
  * Domain Path: /languages

--- a/wp-rest-api-log.php
+++ b/wp-rest-api-log.php
@@ -3,7 +3,7 @@
  * Plugin Name: REST API Log
  * Description: Logs requests and responses for the REST API
  * Author: Pete Nelson
- * Version: 1.4.0
+ * Version: 1.3.0
  * Plugin URI: https://github.com/petenelson/wp-rest-api-log
  * Text Domain: wp-rest-api-log
  * Domain Path: /languages


### PR DESCRIPTION
* Changed plugin name to REST API Log
* Changed the wp-rest-api-log post type 'public' setting to false to prevent it from showing up in searches.
* Updated Highlight JS version to 9.7.0
