### PR TITLE
Set show_in_nav_menus to false for custom taxonomies

### DIFF
--- a/includes/class-wp-rest-api-log-post-type.php
+++ b/includes/class-wp-rest-api-log-post-type.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'WP_REST_API_Log_Post_Type' ) ) {
 				'show_ui'             => true,
 				'show_in_menu'        => 'tools.php',
 				'show_in_admin_bar'   => false,
-				'show_in_nav_menus'   => true,
+				'show_in_nav_menus'   => false,
 				'publicly_queryable'  => true,
 				'exclude_from_search' => true,
 				'has_archive'         => false,

--- a/includes/class-wp-rest-api-log-post-type.php
+++ b/includes/class-wp-rest-api-log-post-type.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'WP_REST_API_Log_Post_Type' ) ) {
 				'show_ui'             => true,
 				'show_in_menu'        => 'tools.php',
 				'show_in_admin_bar'   => false,
-				'show_in_nav_menus'   => false,
+				'show_in_nav_menus'   => true,
 				'publicly_queryable'  => true,
 				'exclude_from_search' => true,
 				'has_archive'         => false,
@@ -86,7 +86,7 @@ if ( ! class_exists( 'WP_REST_API_Log_Post_Type' ) ) {
 			$args = array(
 				'labels'            => $labels,
 				'public'            => true,
-				'show_in_nav_menus' => true,
+				'show_in_nav_menus' => false,
 				'show_admin_column' => false,
 				'hierarchical'      => false,
 				'show_tagcloud'     => true,


### PR DESCRIPTION
I see no reason why these should show up in /wp-admin/nav-menus.php