### PR TITLE
Don't cast multi-dimensional query string parameters to strings

### DIFF
--- a/admin/partials/wp-rest-api-log-view-entry.php
+++ b/admin/partials/wp-rest-api-log-view-entry.php
@@ -129,7 +129,9 @@ $download_urls = WP_REST_API_Log_Controller::get_download_urls( $entry );
 						'entry' => $entry,
 					)
 				); ?>
-				<pre><code class="json"><?php echo wp_json_encode( $entry->request->body_params, $json_display_options['request']['body_params'] ); ?></code></pre>
+				<pre><code class="json"><?php echo wp_json_encode(
+				        $entry->request->body_params,
+                            $json_display_options['request']['body_params'] ); ?></code></pre>
 			</div>
 		</div>
 

--- a/includes/class-wp-rest-api-log-db.php
+++ b/includes/class-wp-rest-api-log-db.php
@@ -174,8 +174,10 @@ if ( ! class_exists( 'WP_REST_API_Log_DB' ) ) {
 				if ( ! empty( $args[ $request ][ $type ] ) ) {
 					foreach ( $args[ $request ][ $type ] as $key => $value ) {
 
-						if ( is_array( $value ) && 1 === count( $value ) ) {
-							$value = reset( $value );
+						if( is_array($value) &&
+						    1 === count($value) &&
+						    $type === 'headers'){
+							$value = reset($value);
 						}
 
 						if ( ! empty( $value ) ) {
@@ -199,8 +201,10 @@ if ( ! class_exists( 'WP_REST_API_Log_DB' ) ) {
 				if ( ! empty( $args[ $response ][ $type ] ) ) {
 					foreach ( $args[ $response ][ $type ] as $key => $value ) {
 
-						if ( is_array( $value ) && 1 === count( $value ) ) {
-							$value = $value[0];
+						if( is_array($value) &&
+						    1 === count($value) &&
+						    'headers' === $type ){
+							$value = reset($value);
 						}
 
 						if ( ! empty( $value ) ) {

--- a/includes/class-wp-rest-api-log-request-response-base.php
+++ b/includes/class-wp-rest-api-log-request-response-base.php
@@ -122,7 +122,13 @@ if ( ! class_exists( 'WP_REST_API_Log_API_Request_Response_Base' ) ) {
 			// Run esc_html on the request fields.
 			foreach( $request_fields as $field ) {
 				if ( is_array( $entry->request->$field ) ) {
-					$entry->request->$field = array_map( 'esc_html', $entry->request->$field );
+					array_walk_recursive(
+						$entry->request->$field,
+						function ( &$v, &$k ) {
+							$v = esc_html( $v );
+							$k = esc_html( $k );
+						}
+					);
 				} else {
 					$entry->request->$field = esc_html( $entry->request->$field );
 				}
@@ -131,7 +137,13 @@ if ( ! class_exists( 'WP_REST_API_Log_API_Request_Response_Base' ) ) {
 			// Run esc_html on the response fields.
 			foreach( $response_fields  as $field ) {
 				if ( is_array( $entry->response->$field ) ) {
-					$entry->response->$field = array_map( 'esc_html', $entry->response->$field );
+					array_walk_recursive(
+						$entry->response->$field,
+						function ( &$v, &$k ) {
+							$v = esc_html( $v );
+							$k = esc_html( $k );
+						}
+					);
 				} else {
 					$entry->response->$field = esc_html( $entry->response->$field );
 				}


### PR DESCRIPTION
We have an REST API plugin that uses multi-dimensional query string parameters (eg `http://src.wordpress-develop.dev/wp-json/ee/v4.8.36/events?where[EVT_ID][]=<&where[EVT_ID][]=300&limit=2`, notice that `where` isn't just a string, it's actually a 2D array).
When these requests gets logged by your great plugin they look like this: https://drive.google.com/a/eventespresso.com/file/d/0B5P8GXTvZgfMU1E0eEFZdm9aWFE/view?usp=drivesdk
ie, the array is cast to a string, which isn't very helpful.

With this commit, it remains an array, eg https://drive.google.com/a/eventespresso.com/file/d/0B5P8GXTvZgfMRzIyYW12dDB5a0k/view?usp=drivesdk.