### PR TITLE
Log OPTIONS HTTP requests

### DIFF
--- a/includes/class-wp-rest-api-log-common.php
+++ b/includes/class-wp-rest-api-log-common.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'WP_REST_API_Log_Common' ) ) {
 
 
 		static public function valid_methods() {
-			return apply_filters( self::PLUGIN_NAME . '-valid-methods', array( 'GET', 'POST', 'PUT', 'PATCH', 'DELETE' ) );
+			return apply_filters( self::PLUGIN_NAME . '-valid-methods', array( 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS' ) );
 		}
 
 


### PR DESCRIPTION
`OPTIONS` HTTP requests to the WordPress REST API are quite common, so ideally these should be logged as well.

Ref
https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/
https://codedestine.com/rest-options-restful-web-services/

Thank you!