### PR TITLE
Fix `array_walk_recursive` callback sugnature in PHP 8.0

### DIFF
--- a/includes/class-wp-rest-api-log-request-response-base.php
+++ b/includes/class-wp-rest-api-log-request-response-base.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'WP_REST_API_Log_API_Request_Response_Base' ) ) {
 				if ( is_array( $entry->request->$field ) ) {
 					array_walk_recursive(
 						$entry->request->$field,
-						function ( &$v, &$k ) {
+						function ( &$v, $k ) {
 							$v = esc_html( $v );
 							$k = esc_html( $k );
 						}
@@ -139,7 +139,7 @@ if ( ! class_exists( 'WP_REST_API_Log_API_Request_Response_Base' ) ) {
 				if ( is_array( $entry->response->$field ) ) {
 					array_walk_recursive(
 						$entry->response->$field,
-						function ( &$v, &$k ) {
+						function ( &$v, $k ) {
 							$v = esc_html( $v );
 							$k = esc_html( $k );
 						}


### PR DESCRIPTION
In PHP 8.0 the `array_walk` and the `array_walk_recursive` functions callback signature changed. 
They does not accept reference for the second (or third) parameter anymore.  
Unfortunately this fact only documented for the `array_walk` function.  
See here: https://www.php.net/manual/en/function.array-walk.php#refsect1-function.array-walk-changelog