### PR TITLE
Use empty string, not `null` for menu parent

### DIFF
--- a/admin/class-wp-rest-api-log-admin.php
+++ b/admin/class-wp-rest-api-log-admin.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'WP_REST_API_Log_Admin' ) ) {
 		static public function admin_menu() {
 
 			add_submenu_page(
-				null,
+				'',
 				__( 'REST API Log Entries', 'wp-rest-api-log' ),
 				'',
 				'read_' . WP_REST_API_Log_DB::POST_TYPE,


### PR DESCRIPTION
Fixes:

```
PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/html/wp-includes/functions.php on line 7374
PHP Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/html/wp-includes/functions.php on line 2196
PHP Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:7374) in /var/www/html/wp-includes/functions.php on line 7182
```